### PR TITLE
Fix appdata.xml which was failing to validate

### DIFF
--- a/com.endlessnetwork.frogsquash.appdata.xml
+++ b/com.endlessnetwork.frogsquash.appdata.xml
@@ -21,19 +21,19 @@
   <screenshots>
     <screenshot type="default">
       <image>https://github.com/endless-network/FrogSquash_Binary/raw/master/F4.jpg</image>
-    <caption>Beat your score.</caption>
+    <caption>Beat your score</caption>
     </screenshot>
     <screenshot>
       <image>https://github.com/endless-network/FrogSquash_Binary/raw/master/F3.jpg</image>
-      <caption>Program your frog.</caption>
+      <caption>Program your frog</caption>
     </screenshot>
     <screenshot>
       <image>https://github.com/endless-network/FrogSquash_Binary/raw/master/F2.jpg</image>
-      <caption>Watch your step.</caption>
+      <caption>Watch your step</caption>
     </screenshot>
     <screenshot>
         <image>https://github.com/endless-network/FrogSquash_Binary/raw/master/F1.jpg</image>
-        <caption>Choose from multiple animals.</caption>
+        <caption>Choose from multiple animals</caption>
     </screenshot>
   </screenshots>
     <content_rating type="oars-1.1">


### PR DESCRIPTION
The following validator was failing...

    flatpak run org.freedesktop.appstream-glib validate com.endlessnetwork.frogsquash.appdata.xml

With this output:

    com.endlessnetwork.frogsquash.appdata.xml: FAILED:
    • style-invalid         : <caption> cannot end in '.' [Beat your score.]
    • style-invalid         : <caption> cannot end in '.' [Choose from multiple animals.]
    • style-invalid         : <caption> cannot end in '.' [Program your frog.]
    • style-invalid         : <caption> cannot end in '.' [Watch your step.]